### PR TITLE
Upgrade to MJML 4.15.3 and NodeJS20

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -12,10 +12,10 @@ jobs:
               with:
                   ref: ${{ github.head_ref }}
 
-            - run: yarn install
+            - run: npm install
 
             - name: Prettier
-              run: yarn prettier --check "{!(vendor|node_modules)/**/*,*}.{js,ts,jsx,tsx,vue,xml,json,blade.php,css,md,yml,html}"
+              run: npx prettier --check "{!(vendor|node_modules)/**/*,*}.{js,ts,jsx,tsx,vue,xml,json,blade.php,css,md,yml,html}"
 
             - name: Pint
               uses: aglipanci/laravel-pint-action@2.3.1

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -30,7 +30,7 @@ jobs:
                   echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
             - name: Install dependencies
-              run: composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+              run: composer update --prefer-dist --no-interaction
 
             - name: Execute tests
               run: vendor/bin/phpunit

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [8.2, 8.3, 8.4]
+                php: [8.2, 8.3]
 
         name: P${{ matrix.php }} - ${{ matrix.os }}
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,10 +9,9 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [8.2]
-                stability: [prefer-lowest, prefer-stable]
+                php: [8.2, 8.3, 8.4]
 
-        name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
+        name: P${{ matrix.php }} - ${{ matrix.os }}
 
         steps:
             - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 .env
 yarn-error.log
 /bin/*
+package-lock.json

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
 source .env
-
 targets=("darwin-x64" "darwin-arm64" "linux-x64" "linux-arm64")
 
 for target in "${targets[@]}"
 do
   echo "Building: $target"
-  yarn pkg --target=node18-$target ./build/mjml.js --compress=Brotli --output=./bin/mjml-$target
+  npx pkg --target=node20-"$target" ./build/mjml.js --compress=Brotli --output=./bin/mjml-"$target"
 done
 
 echo "Uploading to DigitalOcean Spaces"
-s3cmd --host https://nyc3.digitaloceanspaces.com --host-bucket "%(bucket)s.nyc3.digitaloceanspaces.com" --acl-public --access_key $SPACES_KEY --secret_key $SPACES_SECRET sync ./bin/mjml* s3://defectivecode-packages/packages/mjml/$VERSION/
+s3cmd --host https://nyc3.digitaloceanspaces.com --host-bucket "%(bucket)s.nyc3.digitaloceanspaces.com" --acl-public --access_key "$SPACES_KEY" --secret_key "$SPACES_SECRET" sync ./bin/mjml* s3://defectivecode-packages/packages/mjml/"$VERSION"/
 
 echo "Cleaning up"
 find ./bin ! -name '.gitkeep' -type f -delete

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
     "devDependencies": {
         "@prettier/plugin-xml": "^2.2.0",
-        "pkg": "^5.8.1",
         "prettier": "^2.8.7",
         "prettier-package-json": "^2.8.0"
     },
     "dependencies": {
+        "@yao-pkg/pkg": "^5.11.5",
         "html-minifier-terser": "^7.2.0",
         "js-beautify": "^1.14.9",
         "lodash": "^4.17.21",
-        "mjml": "^4.14.1",
+        "mjml": "4.15.3",
         "snakecase": "^1.0.0"
     },
     "name": "mjml"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,14 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+<?xml version="1.0" encoding="UTF-8" ?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+>
   <testsuites>
     <testsuite name="Unit">
       <directory suffix="Test.php">./tests</directory>
     </testsuite>
   </testsuites>
   <php>
-    <server name="APP_ENV" value="testing"/>
-    <server name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
-    <server name="RAY_ENABLED" value="(true)"/>
+    <server name="APP_ENV" value="testing" />
+    <server name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF" />
+    <server name="RAY_ENABLED" value="(true)" />
   </php>
   <source>
     <include>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,23 +1,18 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-    bootstrap="vendor/autoload.php"
-    colors="true"
->
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
-    <php>
-        <server name="APP_ENV" value="testing" />
-        <server name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF" />
-        <server name="RAY_ENABLED" value="(true)" />
-    </php>
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <server name="APP_ENV" value="testing"/>
+    <server name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
+    <server name="RAY_ENABLED" value="(true)"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/MJML.php
+++ b/src/MJML.php
@@ -37,7 +37,7 @@ class MJML
 
     protected Config $config;
 
-    public function __construct(Config $config = null)
+    public function __construct(?Config $config = null)
     {
         $this->config = $config ?? new Config();
     }

--- a/src/PullBinary.php
+++ b/src/PullBinary.php
@@ -8,7 +8,7 @@ use RuntimeException;
 
 class PullBinary
 {
-    public const MJML_VERSION = '4.14.1';
+    public const MJML_VERSION = '4.15.3';
 
     public const BASE_DOWNLOAD_URL = 'https://downloads.defectivecode.com/packages/mjml/';
 
@@ -84,7 +84,6 @@ class PullBinary
 
         echo "Granting run permissions to {$binaryPath} binary.\n";
         chmod($binaryPath, 0755);
-
     }
 
     protected static function resolveOperatingSystem(string $operatingSystem): string

--- a/tests/MJMLTest.php
+++ b/tests/MJMLTest.php
@@ -22,6 +22,7 @@ class MJMLTest extends TestCase
                     </mj-column>
                 </mj-section>
             </mj-body>
+        </mjml>
     MJML;
 
     protected string $invalidMjml = '<mjml><mj-body><mj-column></mjml></mj-body>';
@@ -122,7 +123,7 @@ class MJMLTest extends TestCase
         $this->assertFalse($mjml->getConfig()->keepComments);
     }
 
-    protected function mockShellCall(Config $config = null): MockInterface
+    protected function mockShellCall(?Config $config = null): MockInterface
     {
         $mjml = $this->mock(MJML::class)
             ->makePartial()


### PR DESCRIPTION
## Changes
1. Upgrades to MJML 4.15.3
2. Upgrades to NodeJS 20
3. Switches to npm over yarn.
4. Switches to `@yao-pkg/pkg` over `pkg` as `pkg` has been archived.
5. Adds PHP `8.3` to test suite.