### PR TITLE
Upgrade to Node22, resolve buffer overflow issue, sign MacOS arm64 binary

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -6,11 +6,18 @@ targets=("darwin-x64" "darwin-arm64" "linux-x64" "linux-arm64")
 for target in "${targets[@]}"
 do
   echo "Building: $target"
-  npx pkg --target=node20-"$target" ./build/mjml.js --compress=Brotli --output=./bin/mjml-"$target"
+  npx pkg --target=node22-"$target" ./build/mjml.js --compress=Brotli --output=./bin/mjml-"$target"
 done
 
-echo "Uploading to DigitalOcean Spaces"
-s3cmd --host https://nyc3.digitaloceanspaces.com --host-bucket "%(bucket)s.nyc3.digitaloceanspaces.com" --acl-public --access_key "$SPACES_KEY" --secret_key "$SPACES_SECRET" sync ./bin/mjml* s3://defectivecode-packages/packages/mjml/"$VERSION"/
+echo "Signing MacOS ARM64 binary."
+macos_arm64_binary="./bin/mjml-darwin-arm64"
+codesign --remove-signature "$macos_arm64_binary"
+codesign --sign "$MAC_DEVELOPER_KEY" --timestamp --options runtime --entitlements ./build/entitlements.plist "$macos_arm64_binary"
+zip "$macos_arm64_binary".zip "$macos_arm64_binary"
+xcrun notarytool submit "$macos_arm64_binary".zip --keychain-profile "$MACOS_NOTARIZATION" --wait
 
-echo "Cleaning up"
-find ./bin ! -name '.gitkeep' -type f -delete
+echo "Uploading to DigitalOcean Spaces"
+s3cmd --host https://nyc3.digitaloceanspaces.com --host-bucket "defectivecode-packages.nyc3.digitaloceanspaces.com" --acl-public --access_key "$SPACES_KEY" --secret_key "$SPACES_SECRET" sync ./bin/mjml* s3://defectivecode-packages/packages/mjml/"$VERSION"/
+
+#echo "Cleaning up"
+#find ./bin ! -name '.gitkeep' -type f -delete

--- a/build/entitlements.plist
+++ b/build/entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd"\>
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.debugger</key>
+    <true/>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
         "prettier-package-json": "^2.8.0"
     },
     "dependencies": {
-        "@yao-pkg/pkg": "^5.11.5",
+        "@yao-pkg/pkg": "^6.5.1",
         "html-minifier-terser": "^7.2.0",
         "js-beautify": "^1.14.9",
         "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "mjml": "4.15.3",
         "snakecase": "^1.0.0"
     },

--- a/src/MJML.php
+++ b/src/MJML.php
@@ -91,10 +91,12 @@ class MJML
     {
         $binary = PullBinary::resolveBinaryPath(php_uname('s'), php_uname('m'));
 
-        exec("{$binary} {$arguments}", $output, $code);
+        $output = tempnam(sys_get_temp_dir(), 'mjml_output');
+
+        exec("{$binary} {$arguments} > {$output} 2>&1", result_code: $code);
 
         return [
-            implode("\n", $output),
+            file_get_contents($output),
             $code,
         ];
     }


### PR DESCRIPTION
Mostly a chore PR:

1. Upgrades the binaries to use Node 22.
2. Removes the ad hoc signature and uses a full signature for easier running on macOS arm64.
3. Fixes a buffer overflow issue where long emails would be cut off when generated.
