### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [8.2, 8.3]
+                php: [8.4, 8.5]
 
         name: P${{ matrix.php }} - ${{ matrix.os }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .idea
 .php_cs
 .php_cs.cache
-.phpunit.result.cache
+.phpunit.cache
 *.lock
 vendor
 node_modules

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,5 +3,5 @@
     "trailingComma": "es5",
     "tabWidth": 4,
     "singleQuote": true,
-    "plugins": ["@prettier/plugin-xml"]
+    "plugins": ["@prettier/plugin-xml", "prettier-plugin-packagejson"]
 }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,11 +10,11 @@ Please email your findings directly to our Security Team at security@defectiveco
 
 When reporting a security vulnerability, include as much information as possible, such as:
 
--   A clear and concise description of the issue
--   Steps to reproduce the vulnerability
--   Affected software and versions
--   Potential impact of the vulnerability
--   A proof of concept demonstrating the exploit, if possible
+- A clear and concise description of the issue
+- Steps to reproduce the vulnerability
+- Affected software and versions
+- Potential impact of the vulnerability
+- A proof of concept demonstrating the exploit, if possible
 
 This comprehensive information will enable our team to better understand and promptly address the issue.
 
@@ -22,10 +22,10 @@ This comprehensive information will enable our team to better understand and pro
 
 Upon receiving your report, we commit to:
 
--   Acknowledge receipt of your report within 72 hours
--   Review and evaluate the vulnerability in a timely manner
--   Provide you with updates on our progress, as appropriate
--   Fix and disclose the verified vulnerability within 30 days of receipt, unless extenuating circumstances require a longer resolution time
+- Acknowledge receipt of your report within 72 hours
+- Review and evaluate the vulnerability in a timely manner
+- Provide you with updates on our progress, as appropriate
+- Fix and disclose the verified vulnerability within 30 days of receipt, unless extenuating circumstances require a longer resolution time
 
 ## 4. Credit and Recognition
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "defectivecode/mjml",
+    "description": "Compile MJML to responsive HTML emails directly in PHP without requiring Node.js. Wraps the official MJML engine with full Laravel integration.",
     "type": "laravel",
     "license": "MIT",
     "autoload": {
@@ -19,14 +20,14 @@
         }
     ],
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "illuminate/support": "*"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.3",
-        "nunomaduro/collision": "^7.0",
-        "phpunit/phpunit": "^10.0",
-        "laravel/pint": "^1.8"
+        "orchestra/testbench": "^10.0",
+        "nunomaduro/collision": "^8.8",
+        "phpunit/phpunit": "^12.0",
+        "laravel/pint": "^1.25"
     },
     "extra": {
         "laravel": {

--- a/docs/en.md
+++ b/docs/en.md
@@ -151,27 +151,27 @@ $html = (new MJML)
 Our package follows the [same configuration](https://github.com/mjmlio/mjml/tree/master) as the official MJML package
 except for the following:
 
--   `preprocessors` - This option is not available. Please open a pull request if you would like to add this option.
--   `minifyOptions` - We use `html-minifier-terser` while the official package uses `html-minifier` for minification. We
-    decided to switch the processor because `html-minifer` is no longer maintained and has a few security issues associate
-    with it.
+- `preprocessors` - This option is not available. Please open a pull request if you would like to add this option.
+- `minifyOptions` - We use `html-minifier-terser` while the official package uses `html-minifier` for minification. We
+  decided to switch the processor because `html-minifer` is no longer maintained and has a few security issues associate
+  with it.
 
 ## Fonts
 
 Our package uses the following fonts by default:
 
--   Open Sans: 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700
--   Droid Sans: 'https://fonts.googleapis.com/css?family=Droid+Sans:300,400,500,700
--   Lato: https://fonts.googleapis.com/css?family=Lato:300,400,500,700
--   Roboto: https://fonts.googleapis.com/css?family=Roboto:300,400,500,700
--   Ubuntu: https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700
+- Open Sans: 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700
+- Droid Sans: 'https://fonts.googleapis.com/css?family=Droid+Sans:300,400,500,700
+- Lato: https://fonts.googleapis.com/css?family=Lato:300,400,500,700
+- Roboto: https://fonts.googleapis.com/css?family=Roboto:300,400,500,700
+- Ubuntu: https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700
 
 You may change the fonts by using the following methods:
 
--   `addFont(string $font, string $url)` - Add a font to the list of fonts.
--   `removeFont(string$font)` - Remove a font from the list of fonts.
--   `setFonts(array $fonts)` - Set the list of fonts. You should provide an array of fonts in this
-    format: `['font-name' => 'font-url']`.
+- `addFont(string $font, string $url)` - Add a font to the list of fonts.
+- `removeFont(string$font)` - Remove a font from the list of fonts.
+- `setFonts(array $fonts)` - Set the list of fonts. You should provide an array of fonts in this
+  format: `['font-name' => 'font-url']`.
 
 ## Comments
 
@@ -189,10 +189,10 @@ this behavior by calling the `ignoreIncludes(bool $ignore)` method.
 Our package will beautify the HTML using [`js-beautify`](https://www.npmjs.com/package/js-beautify) with the following
 default options:
 
--   indentSize: 2
--   wrapAttributesIndentSize: 2
--   maxPreserveNewline: 0
--   preserveNewlines: false
+- indentSize: 2
+- wrapAttributesIndentSize: 2
+- maxPreserveNewline: 0
+- preserveNewlines: false
 
 > While `js-beautify` uses snake_case to provide options, you should use camelCase when using our package. We made this
 > choice to keep our package consistent with the rest of the configuration options. Our package will automatically
@@ -200,36 +200,36 @@ default options:
 
 You may override any of these options by providing a valid `js-beautify` configuration using the following methods:
 
--   `setBeautifyOptions(array $options)` - Set the `js-beautify` options.
--   `addBeautifyOption(string $option, mixed $value)` - Adds a `js-beautify` option.
--   `removeBeautifyOption(string $option)` - Removes a `js-beautify` option.
+- `setBeautifyOptions(array $options)` - Set the `js-beautify` options.
+- `addBeautifyOption(string $option, mixed $value)` - Adds a `js-beautify` option.
+- `removeBeautifyOption(string $option)` - Removes a `js-beautify` option.
 
 ## Minify
 
 Our package will minify the HTML using [`html-minifier-terser`](https://www.npmjs.com/package/html-minifier-terser) with
 the following default options:
 
--   collapseWhitespace: true
--   minifyCSS: false
--   caseSensitive: true
--   removeEmptyAttributes: true
+- collapseWhitespace: true
+- minifyCSS: false
+- caseSensitive: true
+- removeEmptyAttributes: true
 
 You may override any of these options by providing a
 valid [`html-minifier-terser`](https://www.npmjs.com/package/html-minifier-terser) configuration using the following
 methods:
 
--   `setMinifyOptions(array $options)` - Set the `html-minifier-terser` options.
--   `addMinifyOption(string $option, mixed $value)` - Adds a `html-minifier-terser` option.
--   `removeMinifyOption(string $option)` - Removes a `html-minifier-terser` option.
+- `setMinifyOptions(array $options)` - Set the `html-minifier-terser` options.
+- `addMinifyOption(string $option, mixed $value)` - Adds a `html-minifier-terser` option.
+- `removeMinifyOption(string $option)` - Removes a `html-minifier-terser` option.
 
 ## Validation Level
 
 Our package will validate the MJML using the `soft` validation level by default. You may change this by using the
 `validationLevel(ValidationLevel $validationLevel)` method. The following validation levels are available:
 
--   `strict` - Your document is going through validation and is not rendered if it has any error
--   `soft` - Your document is going through validation and is rendered, even if it has errors
--   `skip` - Your document is rendered without going through validation.
+- `strict` - Your document is going through validation and is not rendered if it has any error
+- `soft` - Your document is going through validation and is rendered, even if it has errors
+- `skip` - Your document is rendered without going through validation.
 
 ## File Path
 
@@ -241,9 +241,9 @@ method.
 We do not provide any [juice options](https://www.npmjs.com/package/juice) by default. You may add juice options by
 using the following methods:
 
--   `setJuiceOptions(array $options)` - Set the juice options.
--   `addJuiceOption(string $option, mixed $value)` - Adds a juice option.
--   `removeJuiceOption(string $option)` - Removes a juice option.
--   `setJuicePreserveTags(array $tags)` - Set the juice preserve tags.
--   `addJuicePreserveTag(string $tag, mixed $value)` - Adds a juice preserve tag.
--   `removeJuicePreserveTag(string $tag)` - Removes a juice preserve tag.
+- `setJuiceOptions(array $options)` - Set the juice options.
+- `addJuiceOption(string $option, mixed $value)` - Adds a juice option.
+- `removeJuiceOption(string $option)` - Removes a juice option.
+- `setJuicePreserveTags(array $tags)` - Set the juice preserve tags.
+- `addJuicePreserveTag(string $tag, mixed $value)` - Adds a juice preserve tag.
+- `removeJuicePreserveTag(string $tag)` - Removes a juice preserve tag.

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
-    "devDependencies": {
-        "@prettier/plugin-xml": "^2.2.0",
-        "prettier": "^2.8.7",
-        "prettier-package-json": "^2.8.0"
-    },
+    "name": "mjml",
     "dependencies": {
-        "@yao-pkg/pkg": "^6.5.1",
+        "@yao-pkg/pkg": "^6.12.0",
         "html-minifier-terser": "^7.2.0",
-        "js-beautify": "^1.14.9",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
+        "js-beautify": "^1.15.4",
+        "lodash": "^4.17.23",
+        "lodash-es": "^4.17.22",
         "mjml": "4.18.0",
         "snakecase": "^1.0.0"
     },
-    "name": "mjml"
+    "devDependencies": {
+        "@prettier/plugin-xml": "^3.4.2",
+        "prettier": "^3.8.0",
+        "prettier-plugin-packagejson": "^2.5.21"
+    }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,9 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd"
     bootstrap="vendor/autoload.php"
     colors="true"
+    cacheDirectory=".phpunit.cache"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
 >
   <testsuites>
     <testsuite name="Unit">

--- a/src/MJML.php
+++ b/src/MJML.php
@@ -39,7 +39,7 @@ class MJML
 
     public function __construct(?Config $config = null)
     {
-        $this->config = $config ?? new Config();
+        $this->config = $config ?? new Config;
     }
 
     public function isValid(string $mjml): bool

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -6,11 +6,12 @@ namespace DefectiveCode\MJML\Tests;
 
 use BadMethodCallException;
 use DefectiveCode\MJML\Config;
+use PHPUnit\Framework\Attributes\Test;
 use DefectiveCode\MJML\ValidationLevel;
 
 class ConfigTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function itSetsThePropertiesFromAnArray(): void
     {
         $arrayConfig = [
@@ -24,49 +25,49 @@ class ConfigTest extends TestCase
         $this->assertTrue($config->ignoreIncludes);
     }
 
-    /** @test */
+    #[Test]
     public function itReturnsAJsonObjectOfTheConfig(): void
     {
         $this->assertEquals(
             '{"fonts":{"Open Sans":"https:\/\/fonts.googleapis.com\/css?family=Open+Sans:300,400,500,700","Droid Sans":"https:\/\/fonts.googleapis.com\/css?family=Droid+Sans:300,400,500,700","Lato":"https:\/\/fonts.googleapis.com\/css?family=Lato:300,400,500,700","Roboto":"https:\/\/fonts.googleapis.com\/css?family=Roboto:300,400,500,700","Ubuntu":"https:\/\/fonts.googleapis.com\/css?family=Ubuntu:300,400,500,700"},"keepComments":true,"ignoreIncludes":false,"beautify":false,"beautifyOptions":{"indentSize":2,"wrapAttributesIndentSize":2,"maxPreserveNewline":0,"preserveNewlines":false},"minify":false,"minifyOptions":{"collapseWhitespace":true,"minifyCSS":false,"caseSensitive":true,"removeEmptyAttributes":true},"validationLevel":"soft","filePath":".","juiceOptions":[],"juicePreserveTags":[]}',
-            (new Config())->toJson()
+            (new Config)->toJson()
         );
     }
 
-    /** @test */
+    #[Test]
     public function itSetsKeepsComments(): void
     {
         $this->assertTrue((new Config)->keepComments()->keepComments);
     }
 
-    /** @test */
+    #[Test]
     public function itSetsRemovesComments(): void
     {
         $this->assertFalse((new Config)->removeComments()->keepComments);
     }
 
-    /** @test */
+    #[Test]
     public function itSetsIgnoresIncludes(): void
     {
         $this->assertTrue((new Config)->ignoreIncludes()->ignoreIncludes);
         $this->assertFalse((new Config)->ignoreIncludes(false)->ignoreIncludes);
     }
 
-    /** @test */
+    #[Test]
     public function itSetsBeautify(): void
     {
         $this->assertTrue((new Config)->beautify()->beautify);
         $this->assertFalse((new Config)->beautify(false)->beautify);
     }
 
-    /** @test */
+    #[Test]
     public function itSetsMinify(): void
     {
         $this->assertTrue((new Config)->minify()->minify);
         $this->assertFalse((new Config)->minify(false)->minify);
     }
 
-    /** @test */
+    #[Test]
     public function itSetsTheValidationLevel(): void
     {
         $this->assertEquals(
@@ -85,7 +86,7 @@ class ConfigTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function itSetsTheFilePath(): void
     {
         $this->assertEquals(
@@ -94,7 +95,7 @@ class ConfigTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function itSetsTheOptionsOnTheCorrectProperty(): void
     {
         $fonts = [
@@ -107,7 +108,7 @@ class ConfigTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function itAddsAnOptionOnTheCorrectProperty(): void
     {
         $this->assertEquals(
@@ -116,7 +117,7 @@ class ConfigTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function itRemovesAnOptionFromTheCorrectProperty(): void
     {
         $this->assertFalse(
@@ -124,7 +125,7 @@ class ConfigTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function itThrowsAnExceptionIfThePropertyDoesntExist(): void
     {
         $this->expectException(BadMethodCallException::class);

--- a/tests/MJMLTest.php
+++ b/tests/MJMLTest.php
@@ -8,6 +8,7 @@ use Exception;
 use Mockery\MockInterface;
 use DefectiveCode\MJML\MJML;
 use DefectiveCode\MJML\Config;
+use PHPUnit\Framework\Attributes\Test;
 
 class MJMLTest extends TestCase
 {
@@ -27,7 +28,7 @@ class MJMLTest extends TestCase
 
     protected string $invalidMjml = '<mjml><mj-body><mj-column></mjml></mj-body>';
 
-    /** @test */
+    #[Test]
     public function itPassesTheMjmlToTheMJMLBinary(): void
     {
         $mjml = $this->mockShellCall();
@@ -45,7 +46,7 @@ class MJMLTest extends TestCase
         $mjml->render($this->validMjml);
     }
 
-    /** @test */
+    #[Test]
     public function itPassesTheConfigToTheMJMLBinary(): void
     {
         $mjml = $this->mockShellCall();
@@ -53,7 +54,7 @@ class MJMLTest extends TestCase
         $mjml->shouldReceive('exec')
             ->once()
             ->withArgs(function ($args): bool {
-                return str_contains($args, (new Config())->toJson());
+                return str_contains($args, (new Config)->toJson());
             })
             ->andReturn([
                 '<html></html>',
@@ -63,7 +64,7 @@ class MJMLTest extends TestCase
         $mjml->render($this->validMjml);
     }
 
-    /** @test */
+    #[Test]
     public function itThrowsAnExceptionIfExitCodeIsGreaterThan0(): void
     {
         $this->expectException(Exception::class);
@@ -73,7 +74,7 @@ class MJMLTest extends TestCase
         $mjml->shouldReceive('exec')
             ->once()
             ->withArgs(function ($args): bool {
-                return str_contains($args, (new Config())->toJson());
+                return str_contains($args, (new Config)->toJson());
             })
             ->andReturn([
                 '<html></html>',
@@ -83,15 +84,15 @@ class MJMLTest extends TestCase
         $mjml->render($this->validMjml);
     }
 
-    /** @test */
+    #[Test]
     public function itReturnsTheConfig(): void
     {
-        $mjml = new MJML();
+        $mjml = new MJML;
 
         $this->assertInstanceOf(Config::class, $mjml->getConfig());
     }
 
-    /** @test */
+    #[Test]
     public function itSetsTheConfig(): void
     {
         $config = new Config;
@@ -102,7 +103,7 @@ class MJMLTest extends TestCase
         $mjml->shouldReceive('exec')
             ->once()
             ->withArgs(function ($args): bool {
-                return str_contains($args, (new Config())->toJson());
+                return str_contains($args, (new Config)->toJson());
             })
             ->andReturn([
                 '<html></html>',
@@ -112,10 +113,10 @@ class MJMLTest extends TestCase
         $mjml->render($this->validMjml);
     }
 
-    /** @test */
+    #[Test]
     public function itForwardsCallsToTheConfigObject(): void
     {
-        $mjml = new MJML();
+        $mjml = new MJML;
         $mjml->minify()->beautify()->removeComments();
 
         $this->assertTrue($mjml->getConfig()->minify);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,7 @@ use Orchestra\Testbench\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
 Upgrade Dependencies & PHPUnit 12 Migration

  PHP (composer.json)

  - Minimum PHP: >=8.2 → >=8.4
  - orchestra/testbench: ^8.3 → ^10.0
  - nunomaduro/collision: ^7.0 → ^8.8
  - phpunit/phpunit: ^10.0 → ^12.0
  - laravel/pint: ^1.8 → ^1.25
  - Added package description

  JavaScript (package.json)

  - prettier: ^2.8.7 → ^3.8.0
  - @prettier/plugin-xml: ^2.2.0 → ^3.4.2
  - prettier-package-json ^2.8.0 → prettier-plugin-packagejson ^2.5.21
  - @yao-pkg/pkg: ^6.5.1 → ^6.12.0
  - js-beautify: ^1.14.9 → ^1.15.4
  - lodash: ^4.17.21 → ^4.17.23
  - lodash-es: ^4.17.21 → ^4.17.22

  PHPUnit 12 Migration

  - Updated phpunit.xml schema to 12.0
  - Converted /** @test */ annotations to #[Test] attributes